### PR TITLE
changed dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "package-updates"
     schedule:
       interval: "weekly"
-    target-branch: "package-updates"


### PR DESCRIPTION
### TL;DR

Updated Dependabot configuration to target the "package-updates" branch.

### What changed?

Moved the `target-branch` configuration from the bottom of the Dependabot settings to directly after the `directory` setting. The target branch remains set to "package-updates".

### Why make this change?

This change improves the readability and organization of the Dependabot configuration file. By grouping related settings together, it becomes easier for developers to understand and maintain the configuration.