### PR TITLE
dependabot against main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,5 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "package-updates"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### TL;DR

Removed the target branch specification for Dependabot npm updates.

### What changed?

The `target-branch: "package-updates"` line has been removed from the Dependabot configuration file (`.github/dependabot.yml`). This change affects npm package ecosystem updates.

### Why make this change?

By removing the target branch specification, Dependabot will now create pull requests against the default branch of the repository. This simplifies the update process and ensures that package updates are integrated directly into the main development branch, reducing the need for additional merging steps.