### PR TITLE
updated locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.6",
         "tailwindcss": "^3.4.13",
-        "typescript": "^5.6.2"
+        "typescript": "5.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6670,9 +6670,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
### TL;DR

Downgrade TypeScript from version 5.6.2 to 5.3.3

### What changed?

- Updated the TypeScript dependency in `package-lock.json` from version 5.6.2 to 5.3.3
- Adjusted the version specification in the `devDependencies` section from `"^5.6.2"` to `"5.3"`

### Why make this change?

This downgrade may be necessary for compatibility reasons with other dependencies or to address specific issues encountered with TypeScript 5.6.2. It's important to ensure that the project remains stable and functional with this older version of TypeScript.